### PR TITLE
https://huntr.dev/bounties/1-other-klask-io

### DIFF
--- a/src/main/java/io/klask/web/rest/errors/ErrorDTO.java
+++ b/src/main/java/io/klask/web/rest/errors/ErrorDTO.java
@@ -1,5 +1,8 @@
 package io.klask.web.rest.errors;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
+import org.springframework.web.util.HtmlUtils;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -48,5 +51,15 @@ public class ErrorDTO implements Serializable {
 
     public List<FieldErrorDTO> getFieldErrors() {
         return fieldErrors;
+    }
+
+    @JsonGetter("message")
+    public String getHtmlSafeMessage(){
+        return HtmlUtils.htmlEscape(this.message);
+    }
+
+    @JsonGetter("description")
+    public String getHtmlSafeDescription(){
+        return HtmlUtils.htmlEscape(this.description);
     }
 }

--- a/src/main/java/io/klask/web/rest/errors/FieldErrorDTO.java
+++ b/src/main/java/io/klask/web/rest/errors/FieldErrorDTO.java
@@ -1,5 +1,8 @@
 package io.klask.web.rest.errors;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
+import org.springframework.web.util.HtmlUtils;
+
 import java.io.Serializable;
 
 public class FieldErrorDTO implements Serializable {
@@ -30,4 +33,13 @@ public class FieldErrorDTO implements Serializable {
         return message;
     }
 
+    @JsonGetter("message")
+    public String getHtmlSafeMessage(){
+        return HtmlUtils.htmlEscape(this.message);
+    }
+
+    @JsonGetter("field")
+    public String getHtmlSafeDescription(){
+        return HtmlUtils.htmlEscape(this.field);
+    }
 }

--- a/src/test/java/io/klask/web/rest/errors/ErrorXssTest.java
+++ b/src/test/java/io/klask/web/rest/errors/ErrorXssTest.java
@@ -1,0 +1,44 @@
+package io.klask.web.rest.errors;
+
+import io.klask.KlaskApp;
+import io.klask.service.IndexService;
+import junit.framework.TestCase;
+import org.junit.Test;
+import org.junit.experimental.results.ResultMatchers;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = {KlaskApp.class}, webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+public class ErrorXssTest extends TestCase {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private IndexService indexService;
+
+    @Test
+    public void testForXssInSearchInput() throws Exception {
+        indexService.initIndexes();
+        //?page=0&project=&query=testfr"><img/src="X"/onerror=alert(document.domain)>&size=10&sort=_score,desc,
+        mockMvc.perform(
+            MockMvcRequestBuilders
+                .get("/api/_search/files")
+                .param("page","0")
+                .param("project","")
+                .param("query","testfr\"><img/src=\"X\"/onerror=alert(document.domain)>"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string(not(containsString("<"))));
+    }
+
+}


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://huntr.dev/bounties/1-other-klask-io

### ⚙️ Description *

When the search term provided in the bounty description was send, it always lead to an error. That error contained the original search term. For some reasons, the frontend trusts the servers responses and therefore does not escape any of the data send as an error message. 
The backend has been changed so that when an error message is sent out to the frontend, it is always escaped to be safe in html.

### 💻 Technical Description *

The change consist in updating the ErrorDTO by adding getters for jackson, the framework used do serialize the DTO to json, to use a getter which passes the data through HtmlUtils.htmlEscape so those are safe to be used include in HTML pages, even though the content might be (partially) provided by a (malicious) user.

### 🐛 Proof of Concept (PoC) *

The POC is well described in the Bounty itself. Calling http(s)://{klask-io-server}/#/?sort=_score,desc&search=testfr"><img%2Fsrc%3D"X"%2Fonerror%3Dalert(document.domain)> 
will result in 4 js alerts containing the domains hostname part. 

### 🔥 Proof of Fix (PoF) *

After the fix, calling the same url will not result in 4 alert popups, but will show the raw text in the error messages which are supposed to be there.

### 👍 User Acceptance Testing (UAT)

See ErrorXssTest, which checks for html tag starts (<) in the response while causing an error to be returned.